### PR TITLE
Adrv9002 variants support

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -185,7 +185,6 @@ def stage_library(String stage_name) {
                 stage('Update BOOT Files') {
                     println("Board name passed: "+board)
                     println(gauntEnv.branches.toString())
-                    //check_for_marker(board)
                     if (board=="pluto")
                         nebula('dl.bootfiles --board-name=' + board + ' --branch=' + gauntEnv.firmwareVersion + ' --firmware', true, true, true)
                     else
@@ -254,7 +253,6 @@ def stage_library(String stage_name) {
                     dir ('recovery'){
                         try{
                             echo "Fetching reference boot files"
-                            //check_for_marker(board)
                             nebula('dl.bootfiles --board-name=' + board + ' --source-root="' + gauntEnv.nebula_local_fs_source_root + '" --source=' + gauntEnv.bootfile_source
                                 +  ' --branch="' + ref_branch.toString() + '"') 
                             echo "Extracting reference fsbl and u-boot"

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -442,7 +442,7 @@ def stage_library(String stage_name) {
                             board = board.replaceAll('-', '_')
                             board_name = check.board_name.replaceAll('-', '_')
                             marker = check.marker
-                            cmd = "python3 -m pytest --html=testhtml/report.html --junitxml=testxml/" + board + "_reports.xml --adi-hw-map -v -k 'not stress' -s --uri='ip:"+ip+"' -m " + board_name + " --capture=tee-sys" + " --" + marker
+                            cmd = "python3 -m pytest --html=testhtml/report.html --junitxml=testxml/" + board + "_reports.xml --adi-hw-map -v -k 'not stress' -s --uri='ip:"+ip+"' -m " + board_name + " --capture=tee-sys" + marker
                             def statusCode = sh script:cmd, returnStatus:true
                             publishHTML(target : [escapeUnderscores: false, allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'testhtml', reportFiles: 'report.html', reportName: board, reportTitles: board])
                             // get pytest results for logging
@@ -1161,14 +1161,15 @@ private def get_gitsha(String board){
 }
 
 private def check_for_marker(String board){
+    def marker = ''
+    def board_name = board
     if (board.contains("-v")){
         board_name = board.split("-v")[0]
-        marker = board.split("-v")[1]
+        marker = ' --' + board.split("-v")[1]
         return [board_name:board_name, marker:marker]
     }
     else {
-        board_name = board
-        return board_name
+        return [board_name:board_name, marker:marker]
     }
 }
 


### PR DESCRIPTION
This added support to handle adrv9002 variants. Board names with -v<variant> at the end of their board name are parsed, getting the <variant> to be passed as a marker to pyadi-iio test. 

This also adds a feature that ensures a resource having different variants will only be accessed and used one variant at a time, this is by using the lock feature.

This feature is dependent on nebula config and nebula.