### PR TITLE
Add MATLAB stage

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -543,8 +543,8 @@ def stage_library(String stage_name) {
                 }
                 else
                 {   
-                    sh 'git clone --recursive -b '+gauntEnv.matlab_branch+' '+gauntEnv.matlab_repo
-                    dir('TransceiverToolbox')
+                    sh 'git clone --recursive -b '+gauntEnv.matlab_branch+' '+gauntEnv.matlab_repo+' Toolbox'
+                    dir('Toolbox')
                     {
                         createMFile()
                         sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -539,8 +539,11 @@ def stage_library(String stage_name) {
                         sh 'git submodule update --init'
                     }
                     createMFile()
-                    sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
-                    junit testResults: '*.xml', allowEmptyResults: true
+                    try{
+                        sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
+                    }finally{
+                        junit testResults: '*.xml', allowEmptyResults: true
+                    }
                 }
                 else
                 {   
@@ -549,8 +552,11 @@ def stage_library(String stage_name) {
                     dir('Toolbox')
                     {
                         createMFile()
-                        sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
-                        junit testResults: '*.xml', allowEmptyResults: true
+                        try{
+                            sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
+                        }finally{
+                            junit testResults: '*.xml', allowEmptyResults: true    
+                        }
                     }
                 }
             }

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -531,7 +531,8 @@ def stage_library(String stage_name) {
                 sh 'cp -r /root/.matlabro /root/.matlab'
                 under_scm = isMultiBranchPipeline()
                 if (under_scm)
-                {
+                {   
+                    println("Multibranch pipeline. Checkout scm.")
                     retry(3) {
                         sleep(5)
                         checkout scm
@@ -543,6 +544,7 @@ def stage_library(String stage_name) {
                 }
                 else
                 {   
+                    println("Not a multibranch pipeline. Cloning "+gauntEnv.matlab_branch+" branch from "+gauntEnv.matlab_repo)
                     sh 'git clone --recursive -b '+gauntEnv.matlab_branch+' '+gauntEnv.matlab_repo+' Toolbox'
                     dir('Toolbox')
                     {
@@ -855,6 +857,25 @@ def set_job_trigger(trigger) {
 def set_matlab_commands(List matlab_commands) {
     assert matlab_commands instanceof java.util.List
     gauntEnv.matlab_commands = matlab_commands
+}
+
+/**
+ * Check if project is part of a multibranch pipeline using 'checkout scm'
+ * Declaring the GitHub Project url in a non-multibranch pipeline does not conflict with checking.
+ */
+def isMultiBranchPipeline() {
+    isMultiBranch = false
+    println("Checking if multibranch pipeline..")
+    try
+    {
+        checkout scm
+        isMultiBranch = true
+    }
+    catch(all)
+    {
+        println("Not a multibranch pipeline")
+    }
+    return isMultiBranch
 }
 
 /**
@@ -1287,22 +1308,6 @@ private def String getStackTrace(Throwable aThrowable){
     PrintStream ps = new PrintStream(baos, true);
     aThrowable.printStackTrace(ps);
     return baos.toString();
-}
-
-private def isMultiBranchPipeline() {
-    // Utility to check if current project is a multibranch pipeline job
-    isMultiBranch = false
-    println("Checking if multibranch pipeline..")
-    try
-    {
-        checkout scm
-        isMultiBranch = true
-    }
-    catch(all)
-    {
-        println("Not a multibranch pipeline")
-    }
-    return isMultiBranch
 }
 
 private def  createMFile(){


### PR DESCRIPTION
Additional env variables with default values:

- matlab_release: 'R2021a',
- matlab_repo: 'https://github.com/analogdevicesinc/TransceiverToolbox.git',
- matlab_branch: 'master',
- matlab_commands: [],

MATLAB commands are written using typical MATLAB syntax.
`harness.set_matlab_commands(["ad=adi.utils.libad9361",
                         "ad.download_libad9361()",
                         "addpath(genpath('test'))",
                         "pyenv('Version','/usr/bin/python3')",
                         "runHWTests(getenv('board'))"])`

Multibranch pipelines **do not use** MATLAB repo and branch because the checkout process is done using checkout scm while non-multibranch pipelines manually clone the specified branch of the specified repo. checkout scm fails for non-multibranch pipelines.

isMultiBranchPipeline() checks if the job is a multibranch pipeline using checkout scm. 

createMFile() saves the matlab_commands to an .m file which is run during the MATLAB session. 