### PR TITLE
Integrate Jira issue creation/update

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -187,10 +187,10 @@ def stage_library(String stage_name) {
                         echo "Update BOOT Files unexpectedly failed. ${ex.getMessage()}"
                     }
                     get_gitsha(board)
+                    failing_msg = "'" + ex.getMessage().split('\n').last().replaceAll( /(['])/, '"') + "'"
                     // send logs to elastic
                     if (gauntEnv.send_results){
                         set_elastic_field(board, 'last_failing_stage', 'UpdateBOOTFiles')
-                        failing_msg = "'" + ex.getMessage().split('\n').last().replaceAll( /(['])/, '"') + "'" 
                         set_elastic_field(board, 'last_failing_stage_failure', failing_msg)
                         stage_library('SendResults').call(board)
                     }

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -515,6 +515,17 @@ def stage_library(String stage_name) {
                             }
                         }
                     }catch(Exception ex){
+                        // log Jira
+                        try{
+                            carrier = nebula('update-config board-config carrier --board-name='+board )
+                            daughter = nebula('update-config board-config daughter --board-name='+board )
+                            description = "LibAD9361Tests Failed: ${ex.getMessage()}"
+                            description = "\n{color:#de350b}*"+get_gitsha(board).toMapString()+"*{color}\n".concat(description)
+                        } catch(Exception desc){
+                                println('Error updating description.')
+                        } finally{
+                            logJira([summary:'['+carrier+'-'+daughter+'] libad9361 tests failed.', description:description]) 
+                        }
                         unstable("LibAD9361Tests Failed: ${ex.getMessage()}")
                     }finally{
                         dir('libad9361-iio/build'){

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -374,7 +374,7 @@ def stage_library(String stage_name) {
                             }catch(Exception desc){
                                 println('Error updating description.')
                             }finally{
-                                logJira([board:board, summary:'Linux tests failed.', description:description, attachment:[board+"_diag_report.tar.bz2"]]) 
+                                logJira([board:board, summary:'Linux tests failed.', description:description, attachment:[board+"_diag_report.tar.bz2","dmesg.log"]]) 
                             }
                             unstable("Linux Tests Failed: ${failed_test}")
                         }

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1457,6 +1457,7 @@ private def get_gitsha(String board){
         set_elastic_field(board, 'hdl_hash', hdl_hash)
         set_elastic_field(board, 'linux_hash', linux_hash)
     }
+    return [hdl_hash:hdl_hash, linux_hash:linux_hash]
 }
 
 private def check_for_marker(String board){

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1069,13 +1069,13 @@ def logJira(jiraArgs) {
         }
     }
     // Append [carier-daugther] to summary
+    jiraArgs.board = jiraArgs.board.replaceAll('_', '-')
     try{
-        jiraArgs.summary = "["+nebula('update-config board-config carrier --board-name='+board )+"-"+nebula('update-config board-config daughter --board-name='+board )+" ".concat(jiraArgs.summary)
+        jiraArgs.summary = "["+nebula('update-config board-config carrier --board-name='+jiraArgs.board )+"-"+nebula('update-config board-config daughter --board-name='+jiraArgs.board )+"] ".concat(jiraArgs.summary)
     }catch(Exception summary){
         println('Jira: Cannot append [carier-daugther] to summary.')
     }
     // Include hdl and linux hash if available
-    jiraArgs.board = jiraArgs.board.replaceAll('_', '-')
     try{
         jiraArgs.description = "{color:#de350b}*[hdl_hash:"+get_elastic_field(jiraArgs.board, 'hdl_hash' , 'NA')+", linux_hash:"+get_elastic_field(jiraArgs.board, 'linux_hash' , 'NA')+"]*{color}\n".concat(jiraArgs.description)
         jiraArgs.description = "["+env.JOB_NAME+'-build-'+env.BUILD_NUMBER+"]\n".concat(jiraArgs.description)

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -368,6 +368,20 @@ def stage_library(String stage_name) {
                         }
 
                         if(failed_test && !failed_test.allWhitespace){
+                            // log Jira
+                            def description = ""
+                            try {
+                                carrier = nebula('update-config board-config carrier --board-name='+board )
+                                daughter = nebula('update-config board-config daughter --board-name='+board )
+                                description += "*Missing drivers: " + missing_devs.size().toString() + "* (" + missing_devs.join(", ") + ")\n"
+                                dmesg_errs = readFile("dmesg_err_filtered.log").readLines()
+                                description += "*dmesg errors: ${dmesg_errs.size()}*\n" + dmesg_errs.join("\n")
+                                description = "\n{color:#de350b}*"+get_gitsha(board).toMapString()+"*{color}\n".concat(description)
+                            }catch(Exception desc){
+                                println('Error updating description.')
+                            }finally{
+                                logJira([summary:'['+carrier+'-'+daughter+'] Linux tests failed.', description:description, attachment:[board+"_diag_report.tar.bz2"]]) 
+                            }
                             unstable("Linux Tests Failed: ${failed_test}")
                         }
                     }catch(Exception ex) {

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1528,7 +1528,6 @@ private def get_gitsha(String board){
         set_elastic_field(board, 'hdl_hash', hdl_hash)
         set_elastic_field(board, 'linux_hash', linux_hash)
     }
-    return [hdl_hash:hdl_hash, linux_hash:linux_hash]
 }
 
 private def check_for_marker(String board){

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -196,6 +196,17 @@ def stage_library(String stage_name) {
                     }
                     if (is_nominal_exception)
                         throw new NominalException('UpdateBOOTFiles failed: '+ ex.getMessage())
+                    // log Jira
+                    try {
+                        carrier = nebula('update-config board-config carrier --board-name='+board )
+                        daughter = nebula('update-config board-config daughter --board-name='+board )
+                        description = failing_msg
+                        description = "\n{color:#de350b}*"+get_gitsha(board).toMapString()+"*{color}\n".concat(description)
+                    }catch(Exception desc){
+                        println('Error updating description.')
+                    }finally{
+                        logJira([summary:'['+carrier+'-'+daughter+'] Update BOOT files failed.', description:description, attachment:[board+".log"]]) 
+                    }
                     throw new Exception('UpdateBOOTFiles failed: '+ ex.getMessage())
                 }finally{
                     //archive uart logs

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -61,6 +61,8 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             nebula_config_branch: 'master',
             send_results: false,
             elastic_logs : [:],
+            log_jira: false,
+            log_jira_stages: [],
             max_retry: 3,
             recovery_ref: "SD"
     ]


### PR DESCRIPTION
**logJira(jiraArgs)** method first checks if an issue with summary in the form "[carrier-daughter] Stage failure message" exists in the project.  Carrier and daughter board names are read from nebula-config, requiring these changes https://github.com/sdgtt/nebula-config/pull/2

A comment is added if the issue exists. Otherwise, an issue is created. 

**jiraArgs** is a map for Jira issue fields. The only hard requirement is the issue summary. Default values are assigned to relevant  fields which are overwritten when listed in jiraArgs. If an issue exists and **description** is included in jiraArgs, the description appears in the added comment.

The **attachment** key in jiraArgs should have a list value. Attachments are uploaded for all stages other than the libad9361, work in progress. 

The **log_jira Gauntenv var** should be true to enable Jira issue creation/updates. This is false by default.

**log_jira_stages Gauntenv var** should contain the stage names wherein Jira issue creation/update is allowed. By default this is an empty list such that if the log_jira flag is true, Jira will be accessed wherever logJira method is called.

See https://jira.analog.com/projects/HTH/summary for examples of created issues.