### PR TITLE
Fix SendLogsToElastic stage call from MATLAB pipelines

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -508,7 +508,7 @@ def stage_library(String stage_name) {
                             xmlFile = 'HWTestResults.xml'
                             if(fileExists(xmlFile)){
                                 try{
-                                parseForLogging ('matlab', xmlFile, board)
+                                    parseForLogging ('matlab', xmlFile, board)
                                 }catch(Exception ex){
                                     println('Parsing MATLAB hardware results failed')
                                     echo getStackTrace(ex)
@@ -531,7 +531,7 @@ def stage_library(String stage_name) {
                             xmlFile = 'HWTestResults.xml'
                             if(fileExists(xmlFile)){
                                 try{
-                                parseForLogging ('matlab', xmlFile, board)
+                                    parseForLogging ('matlab', xmlFile, board)
                                 }catch(Exception ex){
                                     println('Parsing MATLAB hardware results failed')
                                     echo getStackTrace(ex)

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -303,10 +303,10 @@ def stage_library(String stage_name) {
                     cmd += ' jenkins_project_name ' + '\'' + env.JOB_NAME + '\''
                     cmd += ' jenkins_agent ' + env.NODE_NAME
                     cmd += ' jenkins_trigger ' + gauntEnv.job_trigger
-                    cmd += ' pytest_errors ' + get_elastic_field(board, 'errors', '0')
-                    cmd += ' pytest_failures ' + get_elastic_field(board, 'failures', '0')
-                    cmd += ' pytest_skipped ' + get_elastic_field(board, 'skipped', '0')
-                    cmd += ' pytest_tests ' + get_elastic_field(board, 'tests', '0')
+                    cmd += ' pytest_errors ' + get_elastic_field(board, 'pytest_errors', '0')
+                    cmd += ' pytest_failures ' + get_elastic_field(board, 'pytest_failures', '0')
+                    cmd += ' pytest_skipped ' + get_elastic_field(board, 'pytest_skipped', '0')
+                    cmd += ' pytest_tests ' + get_elastic_field(board, 'pytest_tests', '0')
                     cmd += ' matlab_errors ' + get_elastic_field(board, 'matlab_errors', '0')
                     cmd += ' matlab_failures ' + get_elastic_field(board, 'matlab_failures', '0')
                     cmd += ' matlab_skipped ' + get_elastic_field(board, 'matlab_skipped', '0')
@@ -1424,10 +1424,6 @@ private def parseForLogging (String stage, String xmlFile, String board) {
     forLogging."${stage_logs}".each {
         cmd = 'cat ' + xmlFile + ' | sed -rn \'s/.*' 
         cmd+= it + '="([0-9]+)".*/\\1/p\''
-        if (stage == 'pytest') {
-            set_elastic_field(board.replaceAll('_', '-'), it, sh(returnStdout: true, script: cmd).trim())
-        }else {
-            set_elastic_field(board.replaceAll('_', '-'), stage + '_' + it, sh(returnStdout: true, script: cmd).trim())
-        }
+        set_elastic_field(board.replaceAll('_', '-'), stage + '_' + it, sh(returnStdout: true, script: cmd).trim())
     }
 }


### PR DESCRIPTION
White spaces in Jenkins job name causes field mismatch in telemetry commands. The job name is passed in quotation marks to fix the issue.

MATLAB test failures, errors, skipped, and total tests are taken from the HWTestResults.xml file which is parsed similar to pytest results. The parsing was rewritten as a function and is called for both MATLAB and pytests.

Added MATLAB fields for boot_logs index requires https://github.com/sdgtt/telemetry/pull/16.

Signed-off-by: Julia Pineda <Julia.Pineda@analog.com>