### PR TITLE
Add serial backend in libiio install

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1197,7 +1197,7 @@ private def install_libiio() {
             bat('build')
             {
                 //sh 'cmake .. -DPYTHON_BINDINGS=ON'
-                bat 'cmake .. -DPYTHON_BINDINGS=ON -DHAVE_DNS_SD=OFF'
+                bat 'cmake .. -DPYTHON_BINDINGS=ON -DWITH_SERIAL_BACKEND=ON -DHAVE_DNS_SD=OFF'
                 bat 'cmake --build . --config Release --install'
             }
         }
@@ -1209,7 +1209,7 @@ private def install_libiio() {
             dir('build')
             {
                 //sh 'cmake .. -DPYTHON_BINDINGS=ON'
-                sh 'cmake .. -DPYTHON_BINDINGS=ON -DHAVE_DNS_SD=OFF'
+                sh 'cmake .. -DPYTHON_BINDINGS=ON -DWITH_SERIAL_BACKEND=ON -DHAVE_DNS_SD=OFF'
                 sh 'make'
                 sh 'make install'
                 sh 'ldconfig'


### PR DESCRIPTION
Add serial backend when installing libiio.
Signed-off-by: Trecia Agoylo <trecia.agoylo@analog.com>