### PR TITLE
MATLAB-elastic updates

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -507,7 +507,7 @@ def stage_library(String stage_name) {
                     }finally{
                             junit testResults: '*.xml', allowEmptyResults: true
                             // get MATLAB hardware test results for logging
-                            xmlFile = 'HWTestResults.xml'
+                            xmlFile = board+'_HWTestResults.xml'
                             if(fileExists(xmlFile)){
                                 try{
                                     parseForLogging ('matlab', xmlFile, board)
@@ -532,7 +532,7 @@ def stage_library(String stage_name) {
                         }finally{
                             junit testResults: '*.xml', allowEmptyResults: true
                             // get MATLAB hardware test results for logging
-                            xmlFile = 'HWTestResults.xml'
+                            xmlFile = board+'_HWTestResults.xml'
                             if(fileExists(xmlFile)){
                                 try{
                                     parseForLogging ('matlab', xmlFile, board)

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -502,6 +502,8 @@ def stage_library(String stage_name) {
                     createMFile()
                     try{
                         sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
+                    }catch (Exception ex){
+                        throw new NominalException(ex.getMessage())
                     }finally{
                             junit testResults: '*.xml', allowEmptyResults: true
                             // get MATLAB hardware test results for logging
@@ -525,6 +527,8 @@ def stage_library(String stage_name) {
                         createMFile()
                         try{
                             sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
+                        }catch (Exception ex){
+                            throw new NominalException(ex.getMessage())
                         }finally{
                             junit testResults: '*.xml', allowEmptyResults: true
                             // get MATLAB hardware test results for logging


### PR DESCRIPTION
Failing MATLAB tests will raise nominal exception to proceed with next stages.
Updated xml file generated to reflect changes inside toolbox repos.