### PR TITLE
Allow custom template for nebula-config generation

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -826,6 +826,7 @@ private def run_agents() {
     def enable_update_boot_pre_docker = gauntEnv.enable_update_boot_pre_docker
     def enable_resource_queuing = gauntEnv.enable_resource_queuing
     def pre_docker_cls = stage_library("UpdateBOOTFiles")
+    docker_args.add('-v /etc/apt/apt.conf.d:/etc/apt/apt.conf.d:ro')
     docker_args.add('-v /etc/default:/default:ro')
     docker_args.add('-v /dev:/dev')
     docker_args.add('-v /usr/app:/app')
@@ -866,6 +867,9 @@ private def run_agents() {
                 docker.image(docker_image_name).inside(docker_args) {
                     try {
                         stage('Setup Docker') {
+                            sh 'apt-get clean'
+                            sh 'cd /var/lib/apt && mv lists lists.bak; mkdir -p lists/partial'
+                            sh 'apt-get clean'
                             sh 'apt update'
                             sh 'apt-get install python3-tk -y'
                             sh 'cp /default/nebula /etc/default/nebula'

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -96,6 +96,7 @@ private def update_agent() {
                                     + ' --netbox-baseurl=' + gauntEnv.netbox_base_url
                                     + ' --netbox-token=' + gauntEnv.netbox_token
                                     + ' --devices-tag=' + gauntEnv.netbox_devices_tag
+                                    + ' --template=' + gauntEnv.netbox_nebula_template
                                     + ' --outfile='+ agent_name, true, true, false)
                             }
                         }else{

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -37,6 +37,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             netbox_base_url: '',
             netbox_token: '',
             netbox_devices_tag: '',
+            netbox_nebula_template: 'template_gen.yaml',
             enable_update_boot_pre_docker: false,
             lock_agent: false,
             board_sub_categories : ['rx2tx2'],


### PR DESCRIPTION
This PR implements:
1. Allow custom template for nebula-config generation
2. Point to apt-ng  cache proxy server