### PR TITLE
fix: check for valid markers

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1747,10 +1747,17 @@ private def get_gitsha(String board){
 private def check_for_marker(String board){
     def marker = ''
     def board_name = board
+    def valid_markers = [ "cmos", "lvds"]
     if (board.contains("-v")){
-        board_name = board.split("-v")[0]
-        marker = ' --' + board.split("-v")[1]
-        return [board_name:board_name, marker:marker]
+        if (board.split("-v")[1] in valid_markers){
+            board_name = board.split("-v")[0]
+            marker = ' --' + board.split("-v")[1]
+            return [board_name:board_name, marker:marker]
+        
+        }else {
+            board_name = board.replace("-v","-")
+            return [board_name:board_name, marker:marker]
+        }
     }
     else {
         return [board_name:board_name, marker:marker]


### PR DESCRIPTION
Signed-off-by: Trecia Agoylo <trecia.agoylo@analog.com>

This is a fix to check_markers method. Check for valid markers for pytest and ignore other -v<variants>. Other -v<variants> are used for resource locking.