### PR TITLE
Add Jenkins credentials in Log Artifacts stage

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -812,7 +812,17 @@ private def log_artifacts(){
             command += " --jenkins-server ${JENKINS_URL}"
             command += " --es-server ${gauntEnv.elastic_server}"
             command += " --job-name ${env.JOB_NAME} --job ${env.BUILD_NUMBER}"
-            run_i(command)
+
+            // Pass Jenkins credentials if jenkins_credentials (credentials id) is set
+            if (gauntEnv.credentials_id != ''){
+                withCredentials([usernamePassword(credentialsId: gauntEnv.credentials_id, 
+                                usernameVariable: 'JENKINS_USER',
+                                passwordVariable: 'JENKINS_PASS')]) {
+                    run_i(command + " --jenkins-username " + JENKINS_USER + " --jenkins-password " + JENKINS_PASS )
+                }
+            } else {
+                run_i(command)
+            }
         }
     }
 }
@@ -1151,6 +1161,15 @@ def set_max_retry(max_retry) {
  */
 def set_job_trigger(trigger) {
     gauntEnv.job_trigger = trigger
+}
+
+/**
+ * Set the credentials_id variable of gauntEnv used in downloading artifacts in Log Artifacts stage
+ * @param credentials_id is a username-password credentials stored in Jenkins with read access
+ * set to '' by default 
+ */
+def set_credentials_id(credentials_id) {
+    gauntEnv.credentials_id = credentials_id
 }
 
 /**

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -76,6 +76,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             log_jira_stages: [],
             max_retry: 3,
             recovery_ref: "SD",
-            log_artifacts: false
+            log_artifacts: false,
+            credentials_id: ''
     ]
 }


### PR DESCRIPTION
I created this to support the changes in telemetry https://github.com/sdgtt/telemetry/pull/34/files

I added a credentials_id variable that should be a Jenkins username-password credential id stored in Jenkins with read access. The default value is an empty string. When the variable is set in the pipeline config, --jenkins-user and --jenkins-pass are appended to the telemetry command string. The username is exposed in the log but the password is hidden.