### PR TITLE
MATLAB: Add timeout when running MATLAB

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -587,7 +587,7 @@ def stage_library(String stage_name) {
                     }
                     createMFile()
                     try{
-                        sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
+                        sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' timeout -s KILL '+gauntEnv.matlab_timeout+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
                         xmlFile =  sh(returnStdout: true, script: 'ls | grep _*Results.xml').trim()
                     }catch (Exception ex){
                         // log Jira
@@ -622,7 +622,7 @@ def stage_library(String stage_name) {
                     {
                         createMFile()
                         try{
-                            sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
+                            sh 'IIO_URI="ip:'+ip+'" board="'+board+'" elasticserver='+gauntEnv.elastic_server+' timeout -s KILL '+gauntEnv.matlab_timeout+' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay -r "run(\'matlab_commands.m\');exit"'
                             xmlFile =  sh(returnStdout: true, script: 'ls | grep _*Results.xml').trim()
                         }catch (Exception ex){
                             // log Jira
@@ -1180,6 +1180,15 @@ def set_credentials_id(credentials_id) {
 def set_matlab_commands(List matlab_commands) {
     assert matlab_commands instanceof java.util.List
     gauntEnv.matlab_commands = matlab_commands
+}
+
+/**
+ * Set timeout for MATLAB process
+ * @param matlab_timeout string in format <value><unit> for running MATLAB executable
+ * For example: "10m" (default)
+ */
+def set_matlab_timeout(matlab_timeout) {
+    gauntEnv.matlab_timeout = matlab_timeout
 }
 
 /**

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -65,6 +65,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             matlab_repo: 'https://github.com/analogdevicesinc/TransceiverToolbox.git',
             matlab_branch: 'master',
             matlab_commands: [],
+            matlab_timeout: '10m',
             no_os_repo: 'https://github.com/analogdevicesinc/no-OS.git',
             no_os_branch: 'master',
             vivado_ver: '2019.1',


### PR DESCRIPTION
This PR addresses the hang issue on Pluto hw tests. I added a variable matlab_timeout that accepts timeout -s KILL duration as a string. The default value is '10m' for 10 minutes. Toolboxes hw tests do not exceed five minutes on average. The only pipeline where MATLAB stage takes longer to finish is the weekly LTE tests. A setter method is available and should be added for that pipeline.

I tested this using an infinite loop and MATLAB terminated after five minutes.
http://gateway.englab/jenkins/job/Misc/job/Trx_JenkinsfileHW/84/console