### PR TITLE
Update setup docker

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -80,7 +80,7 @@ private def update_agent() {
                 stage('Update agents') {
                     sh 'mkdir -p /usr/app'
                     sh 'rm -rf /usr/app/*'
-                    setupAgent(['nebula','libiio', 'telemetry'], false, update_requirements)
+                    setupAgent(['nebula', 'libiio'], false, update_requirements)
                 }
                 // automatically update nebula config
                 if(gauntEnv.update_nebula_config){
@@ -1827,7 +1827,7 @@ private def check_update_container_lib(update_container_lib=false) {
     }
     else {
         def i;
-        for (i=0; i<repos.size(); i++) {
+        for (i=0; i<branches.size(); i++) {
             if (branches[i] != default_branch){
                 deps.add(dep_map[i])
             } 

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -85,7 +85,8 @@ private def update_agent() {
                 // automatically update nebula config
                 if(gauntEnv.update_nebula_config){
                     stage('Update Nebula Config') {
-                        run_i('if [ -d "nebula-config" ]; then rm -Rf nebula-config; fi')
+                        //run_i('if [ -d "nebula-config" ]; then rm -Rf nebula-config; fi')
+                        run_i('sudo rm -rf nebula-config')
                         if(gauntEnv.nebula_config_source == 'github'){
                             run_i('git clone -b "' + gauntEnv.nebula_config_branch + '" ' + gauntEnv.nebula_config_repo, true)
                         }else if(gauntEnv.nebula_config_source == 'netbox'){

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -979,7 +979,7 @@ private def run_agents() {
         }
     }
     
-    def oneNodeDocker = { agent, num_stages, stages, board, docker_image_name, enable_update_boot_pre_docker_flag, pre_docker_closure, docker_stat, update_container_lib, update_lib_requirements ->
+    def oneNodeDocker = { agent, num_stages, stages, board, docker_image_name, enable_update_boot_pre_docker_flag, pre_docker_closure, docker_stat, update_container, update_requirements ->
         def k
         def ml_variants = ['rx','tx','rx_tx']
         def ml_variant_index = 0
@@ -997,9 +997,9 @@ private def run_agents() {
                             sh 'cp /default/pydistutils.cfg /root/.pydistutils.cfg || true'
                             sh 'mkdir -p /root/.config/pip && cp /default/pip.conf /root/.config/pip/pip.conf || true'
                             sh 'cp /default/pyadi_test.yaml /etc/default/pyadi_test.yaml || true'
-                            def deps = check_update_container_lib(update_container_lib)
+                            def deps = check_update_container_lib(update_container)
                             if (deps.size()>0){
-                                setupAgent(deps, true, update_lib_requirements)
+                                setupAgent(deps, true, update_requirements)
                             }
                             // Above cleans up so we need to move to a valid folder
                             sh 'cd /tmp'
@@ -1074,7 +1074,9 @@ jobs[agent+"-"+board] = {
                                 docker_image,
                                 enable_update_boot_pre_docker,
                                 pre_docker_cls, 
-                                docker_status
+                                docker_status,
+                                update_container_lib,
+                                update_lib_requirements
                             )
                         }
                     }
@@ -1090,7 +1092,9 @@ jobs[agent+"-"+board] = {
                                 docker_image,
                                 enable_update_boot_pre_docker,
                                 pre_docker_cls,
-                                docker_status
+                                docker_status,
+                                update_container_lib,
+                                update_lib_requirements
                             )
                     }
                  };

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -85,7 +85,6 @@ private def update_agent() {
                 // automatically update nebula config
                 if(gauntEnv.update_nebula_config){
                     stage('Update Nebula Config') {
-                        //run_i('if [ -d "nebula-config" ]; then rm -Rf nebula-config; fi')
                         run_i('sudo rm -rf nebula-config')
                         if(gauntEnv.nebula_config_source == 'github'){
                             run_i('git clone -b "' + gauntEnv.nebula_config_branch + '" ' + gauntEnv.nebula_config_repo, true)
@@ -939,7 +938,6 @@ private def run_agents() {
     docker_args.add('-v /etc/apt/apt.conf.d:/etc/apt/apt.conf.d:ro')
     docker_args.add('-v /etc/default:/default:ro')
     docker_args.add('-v /dev:/dev')
-    //docker_args.add('-v /usr/app:/app')
     docker_args.add('-v /etc/timezone:/etc/timezone:ro')
     docker_args.add('-v /etc/localtime:/etc/localtime:ro')
     if (gauntEnv.docker_host_mode) {
@@ -993,15 +991,11 @@ private def run_agents() {
                         stage('Setup Docker') {
                             sh 'apt-get clean'
                             sh 'cd /var/lib/apt && mv lists lists.bak; mkdir -p lists/partial'
-                            //sh 'apt-get clean'
-                            //sh 'apt update'
-                            //sh 'apt-get install python3-tk -y'
                             sh 'cp /default/nebula /etc/default/nebula'
                             sh 'cp /default/pip.conf /etc/pip.conf || true'
                             sh 'cp /default/pydistutils.cfg /root/.pydistutils.cfg || true'
                             sh 'mkdir -p /root/.config/pip && cp /default/pip.conf /root/.config/pip/pip.conf || true'
                             sh 'cp /default/pyadi_test.yaml /etc/default/pyadi_test.yaml || true'
-                            //sh 'cp -r /app/* "${PWD}"/'
                             def deps = check_update_container_lib()
                             if (deps.size()>0){
                                 setupAgent(deps, true, false)
@@ -1731,7 +1725,6 @@ private def install_nebula(update_requirements=false) {
         sh 'pip3 uninstall nebula -y || true'
         run_i('sudo rm -rf nebula')
         run_i('git clone -b ' + gauntEnv.nebula_branch + ' ' + gauntEnv.nebula_repo, true)
-        //sh 'cp -r nebula /usr/app'
         dir('nebula')
         {
             if (update_requirements){
@@ -1750,7 +1743,6 @@ private def install_libiio() {
             bat 'mkdir build'
             bat('build')
             {
-                //sh 'cmake .. -DPYTHON_BINDINGS=ON'
                 bat 'cmake .. -DPYTHON_BINDINGS=ON -DWITH_SERIAL_BACKEND=ON -DHAVE_DNS_SD=OFF'
                 bat 'cmake --build . --config Release --install'
             }
@@ -1759,13 +1751,11 @@ private def install_libiio() {
     else {
         run_i('sudo rm -rf libiio')
         run_i('git clone -b ' + gauntEnv.libiio_branch + ' ' + gauntEnv.libiio_repo, true)
-        //sh 'cp -r libiio /usr/app'
         dir('libiio')
         {
             sh 'mkdir build'
             dir('build')
             {
-                //sh 'cmake .. -DPYTHON_BINDINGS=ON'
                 sh 'cmake .. -DPYTHON_BINDINGS=ON -DWITH_SERIAL_BACKEND=ON -DHAVE_DNS_SD=OFF'
                 sh 'make'
                 sh 'make install'
@@ -1793,7 +1783,6 @@ private def install_telemetry(update_requirements=false){
         // sh 'pip3 uninstall telemetry -y || true'
         run_i('sudo rm -rf telemetry')
         run_i('git clone -b ' + gauntEnv.telemetry_branch + ' ' + gauntEnv.telemetry_repo, true)
-        //sh 'cp -r telemetry /usr/app'
         dir('telemetry')
         {
             if (update_requirements){

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -64,7 +64,8 @@ private def setup_agents() {
 }
 
 private def update_agent() {
-    def docker_status = gauntEnv.enable_docker
+    //def docker_status = gauntEnv.enable_docker
+    def update_requirements = gauntEnv.update_lib_requirements
     def board_map = [:]
 
     // Query each agent for their connected hardware
@@ -79,7 +80,7 @@ private def update_agent() {
                 stage('Update agents') {
                     sh 'mkdir -p /usr/app'
                     sh 'rm -rf /usr/app/*'
-                    setupAgent(['nebula','libiio', 'telemetry'], false, docker_status)
+                    setupAgent(['nebula','libiio', 'telemetry'], false, update_requirements)
                 }
                 // automatically update nebula config
                 if(gauntEnv.update_nebula_config){
@@ -926,7 +927,7 @@ private def log_artifacts(){
 
 private def run_agents() {
     // Start stages for each node with a board
-    def docker_status = gauntEnv.enable_docker
+    def update_container_lib = gauntEnv.update_container_lib
     def jobs = [:]
     def num_boards = gauntEnv.boards.size()
     def docker_args = getDockerConfig(gauntEnv.docker_args)
@@ -936,7 +937,7 @@ private def run_agents() {
     docker_args.add('-v /etc/apt/apt.conf.d:/etc/apt/apt.conf.d:ro')
     docker_args.add('-v /etc/default:/default:ro')
     docker_args.add('-v /dev:/dev')
-    docker_args.add('-v /usr/app:/app')
+    //docker_args.add('-v /usr/app:/app')
     docker_args.add('-v /etc/timezone:/etc/timezone:ro')
     docker_args.add('-v /etc/localtime:/etc/localtime:ro')
     if (gauntEnv.docker_host_mode) {
@@ -990,18 +991,19 @@ private def run_agents() {
                         stage('Setup Docker') {
                             sh 'apt-get clean'
                             sh 'cd /var/lib/apt && mv lists lists.bak; mkdir -p lists/partial'
-                            sh 'apt-get clean'
-                            sh 'apt update'
-                            sh 'apt-get install python3-tk -y'
+                            //sh 'apt-get clean'
+                            //sh 'apt update'
+                            //sh 'apt-get install python3-tk -y'
                             sh 'cp /default/nebula /etc/default/nebula'
                             sh 'cp /default/pip.conf /etc/pip.conf || true'
                             sh 'cp /default/pydistutils.cfg /root/.pydistutils.cfg || true'
                             sh 'mkdir -p /root/.config/pip && cp /default/pip.conf /root/.config/pip/pip.conf || true'
                             sh 'cp /default/pyadi_test.yaml /etc/default/pyadi_test.yaml || true'
-                            sh 'cp -r /app/* "${PWD}"/'
-                            setup_locale()
-                            setup_libserialport()
-                            setupAgent(['libiio','nebula','telemetry'], true, docker_status);
+                            //sh 'cp -r /app/* "${PWD}"/'
+                            def deps = check_update_container_lib()
+                            if (deps.size()>0){
+                                setupAgent(deps, true, false)
+                            }
                             // Above cleans up so we need to move to a valid folder
                             sh 'cd /tmp'
                         }
@@ -1712,46 +1714,35 @@ def String getURIFromSerial(String board){
     return instr_uri
 }
 
-private def clone_nebula() {
+private def install_nebula(update_requirements=false) {
     if (checkOs() == 'Windows') {
         run_i('git clone -b '+  gauntEnv.nebula_branch + ' ' + gauntEnv.nebula_repo, true)
-    }
-    else {
-        sh 'pip3 uninstall nebula -y || true'
-        run_i('git clone -b ' + gauntEnv.nebula_branch + ' ' + gauntEnv.nebula_repo, true)
-        sh 'cp -r nebula /usr/app'
-    }
-}
-
-private def install_nebula() {
-    if (checkOs() == 'Windows') {
         dir('nebula')
         {
-            run_i('pip install -r requirements.txt', true)
+            if (update_requirements){
+                run_i('pip install -r requirements.txt', true)
+            }
             run_i('python setup.py install', true)
         }
     }
     else {
+        sh 'pip3 uninstall nebula -y || true'
+        run_i('sudo rm -r nubula')
+        run_i('git clone -b ' + gauntEnv.nebula_branch + ' ' + gauntEnv.nebula_repo, true)
+        //sh 'cp -r nebula /usr/app'
         dir('nebula')
         {
-            run_i('pip3 install -r requirements.txt', true)
+            if (update_requirements){
+                run_i('pip3 install -r requirements.txt', true)
+            }
             run_i('python3 setup.py install', true)
         }
     }
 }
 
-private def clone_libiio() {
-    if (checkOs() == 'Windows') {
-        run_i('git clone -b ' + gauntEnv.libiio_branch + ' ' + gauntEnv.libiio_repo, true)
-    }
-    else {
-        run_i('git clone -b ' + gauntEnv.libiio_branch + ' ' + gauntEnv.libiio_repo, true)
-        sh 'cp -r libiio /usr/app'
-    }
-}
-
 private def install_libiio() {
     if (checkOs() == 'Windows') {
+        run_i('git clone -b ' + gauntEnv.libiio_branch + ' ' + gauntEnv.libiio_repo, true)
         dir('libiio')
         {
             bat 'mkdir build'
@@ -1764,6 +1755,9 @@ private def install_libiio() {
         }
     }
     else {
+        run_i('sudo rm -r libiio')
+        run_i('git clone -b ' + gauntEnv.libiio_branch + ' ' + gauntEnv.libiio_repo, true)
+        //sh 'cp -r libiio /usr/app'
         dir('libiio')
         {
             sh 'mkdir build'
@@ -1779,38 +1773,30 @@ private def install_libiio() {
                     sh 'python3 setup.py install'
                 }
             }
-
-            
-
         }
     }
 }
 
-private def clone_telemetry(){
+private def install_telemetry(update_requirements=false){
     if (checkOs() == 'Windows') {
         run_i('git clone -b ' + gauntEnv.telemetry_branch + ' ' + gauntEnv.telemetry_repo, true)
-    }else{
-        // sh 'pip3 uninstall telemetry -y || true'
-        run_i('git clone -b ' + gauntEnv.telemetry_branch + ' ' + gauntEnv.telemetry_repo, true)
-        sh 'cp -r telemetry /usr/app'
-    }
-}
-
-private def install_telemetry() {
-    if (checkOs() == 'Windows') {
-        // bat 'git clone https://github.com/tfcollins/telemetry.git'
         dir('telemetry')
         {
-            run_i('pip install -r requirements.txt', true)
+            if (update_requirements){
+                run_i('pip install -r requirements.txt', true)
+            }
             run_i('python setup.py install', true)
         }
-    }
-    else {
-        run_i('pip3 uninstall telemetry -y || true', true)
-        // sh 'git clone https://github.com/tfcollins/telemetry.git'
+    }else{
+        // sh 'pip3 uninstall telemetry -y || true'
+        run_i('sudo rm -r telemetry')
+        run_i('git clone -b ' + gauntEnv.telemetry_branch + ' ' + gauntEnv.telemetry_repo, true)
+        //sh 'cp -r telemetry /usr/app'
         dir('telemetry')
         {
-            run_i('pip3 install -r requirements.txt', true)
+            if (update_requirements){
+                run_i('pip3 install -r requirements.txt', true)
+            }
             run_i('python3 setup.py install', true)
         }
     }
@@ -1835,36 +1821,42 @@ private def setup_libserialport() {
     }
 }
 
-private def setupAgent(deps, skip_cleanup = false, docker_status) {
+private def check_update_container_lib(update_container_lib=false) {
+    def deps = []
+    def default_branch = 'master'
+    def default_repos = ['https://github.com/sdgtt/nebula.git', 'https://github.com/analogdevicesinc/libiio.git', 'https://github.com/sdgtt/telemetry.git']
+    def branches = [gauntEnv.nebula_branch, gauntEnv.libiio_branch, gauntEnv.telemetry_branch]
+    def repos = [gauntEnv.nebula_repo, gauntEnv.libiio_repo, gauntEnv.telemetry_repo]
+    def dep_map = [ 0:'nebula', 1:'libiio', 2:'telemetry']
+    if (update_container_lib){
+        deps = ['nebula', 'libiio', 'telemetry']
+    }
+    else {
+        def i;
+        for (i=0; i<repos.size(); i++) {
+            if (repos[i] != default_repos[i]) || (branches[i] != default_branch){
+                deps.add(dep_map[i])
+            } 
+        }
+    }
+    return deps
+}
+
+private def setupAgent(deps, skip_cleanup = false, update_requirements=false) {
     try {
         def i;
         for (i = 0; i < deps.size; i++) {
             println(deps[i])
             if (deps[i] == 'nebula') {
-                if (docker_status) {
-                    install_nebula()
-                } else {
-                    clone_nebula()
-                    install_nebula()
-                }
+                install_nebula(update_requirements)
             }
             if (deps[i] == 'libiio') {
-                if (docker_status) {
-                    install_libiio()
-                } else {
-                    clone_libiio()
-                    install_libiio()
-                }
+                install_libiio()
             }
             if (deps[i] == 'telemetry') {
-                if (docker_status) {
-                    install_telemetry()
-                } else {
-                    clone_telemetry()
-                    install_telemetry()
-                }
+                install_telemetry(update_requirements)
             }
-        }
+         }
     }
     finally {
         if (!skip_cleanup)

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1834,7 +1834,7 @@ private def check_update_container_lib(update_container_lib=false) {
     else {
         def i;
         for (i=0; i<repos.size(); i++) {
-            if (repos[i] != default_repos[i]) || (branches[i] != default_branch){
+            if ((repos[i] != default_repos[i]) || (branches[i] != default_branch)){
                 deps.add(dep_map[i])
             } 
         }

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1727,7 +1727,7 @@ private def install_nebula(update_requirements=false) {
     }
     else {
         sh 'pip3 uninstall nebula -y || true'
-        run_i('sudo rm -r nebula')
+        run_i('sudo rm -rf nebula')
         run_i('git clone -b ' + gauntEnv.nebula_branch + ' ' + gauntEnv.nebula_repo, true)
         //sh 'cp -r nebula /usr/app'
         dir('nebula')
@@ -1755,7 +1755,7 @@ private def install_libiio() {
         }
     }
     else {
-        run_i('sudo rm -r libiio')
+        run_i('sudo rm -rf libiio')
         run_i('git clone -b ' + gauntEnv.libiio_branch + ' ' + gauntEnv.libiio_repo, true)
         //sh 'cp -r libiio /usr/app'
         dir('libiio')
@@ -1789,7 +1789,7 @@ private def install_telemetry(update_requirements=false){
         }
     }else{
         // sh 'pip3 uninstall telemetry -y || true'
-        run_i('sudo rm -r telemetry')
+        run_i('sudo rm -rf telemetry')
         run_i('git clone -b ' + gauntEnv.telemetry_branch + ' ' + gauntEnv.telemetry_repo, true)
         //sh 'cp -r telemetry /usr/app'
         dir('telemetry')

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -64,7 +64,7 @@ private def setup_agents() {
 }
 
 private def update_agent() {
-    //def docker_status = gauntEnv.enable_docker
+    def docker_status = gauntEnv.enable_docker
     def update_requirements = gauntEnv.update_lib_requirements
     def board_map = [:]
 

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1727,7 +1727,7 @@ private def install_nebula(update_requirements=false) {
     }
     else {
         sh 'pip3 uninstall nebula -y || true'
-        run_i('sudo rm -r nubula')
+        run_i('sudo rm -r nebula')
         run_i('git clone -b ' + gauntEnv.nebula_branch + ' ' + gauntEnv.nebula_repo, true)
         //sh 'cp -r nebula /usr/app'
         dir('nebula')

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1820,9 +1820,7 @@ private def setup_libserialport() {
 private def check_update_container_lib(update_container_lib=false) {
     def deps = []
     def default_branch = 'master'
-    def default_repos = [0:'sdgtt/nebula.git', 1:'analogdevicesinc/libiio.git', 2:'sdgtt/telemetry.git']
     def branches = [0:gauntEnv.nebula_branch, 1:gauntEnv.libiio_branch, 2:gauntEnv.telemetry_branch]
-    def repos = [0:gauntEnv.nebula_repo, 1:gauntEnv.libiio_repo, 2:gauntEnv.telemetry_repo]
     def dep_map = [ 0:'nebula', 1:'libiio', 2:'telemetry']
     if (update_container_lib){
         deps = ['nebula', 'libiio', 'telemetry']
@@ -1830,7 +1828,7 @@ private def check_update_container_lib(update_container_lib=false) {
     else {
         def i;
         for (i=0; i<repos.size(); i++) {
-            if (!(repos[i].contains(default_repos[i])) || (branches[i] != default_branch)){
+            if (branches[i] != default_branch){
                 deps.add(dep_map[i])
             } 
         }

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -928,6 +928,7 @@ private def log_artifacts(){
 
 private def run_agents() {
     // Start stages for each node with a board
+    def docker_status = gauntEnv.enable_docker
     def update_container_lib = gauntEnv.update_container_lib
     def jobs = [:]
     def num_boards = gauntEnv.boards.size()

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -89,7 +89,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             ml_build: '',
             ml_test_stages: 0,
             internal_stages_to_skip: [:], // Number of stages to skip. Used for test skipping for MATLAB
-            update_lib_requirements: false, // Set to true to run installation of requirements.txt
-            update_container_lib: false // Set to true to force update libiio, nebula, telemetry base on master branch
+            update_lib_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
+            update_container_lib: false // Set to true to force update libiio, nebula, telemetry base on master branch inside docker container
     ]
 }

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -27,7 +27,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             required_agent: [],
             firmware_boards: ['pluto','m2k'],
             enable_docker: false,
-            docker_image: 'tfcollins/sw-ci:latest',
+            docker_image: 'tfcollins/test-harness-ci:latest',
             docker_args: ['MATLAB','Vivado'],
             docker_host_mode: true,
             update_nebula_config: true,
@@ -88,6 +88,8 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             ml_branch: '',
             ml_build: '',
             ml_test_stages: 0,
-            internal_stages_to_skip: [:] // Number of stages to skip. Used for test skipping for MATLAB
+            internal_stages_to_skip: [:], // Number of stages to skip. Used for test skipping for MATLAB
+            update_lib_requirements: false, // Set to true to run installation of requirements.txt
+            update_container_lib: false // Set to true to force update libiio, nebula, telemetry base on master branch
     ]
 }

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -89,7 +89,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             ml_build: '',
             ml_test_stages: 0,
             internal_stages_to_skip: [:], // Number of stages to skip. Used for test skipping for MATLAB
-            update_lib_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
+            update_dep_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
             update_container_lib: false // Set to true to force update libiio, nebula, telemetry base on master branch inside docker container
     ]
 }

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -89,7 +89,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             ml_build: '',
             ml_test_stages: 0,
             internal_stages_to_skip: [:], // Number of stages to skip. Used for test skipping for MATLAB
-            update_dep_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
+            update_lib_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
             update_container_lib: false // Set to true to force update libiio, nebula, telemetry base on master branch inside docker container
     ]
 }


### PR DESCRIPTION
 This PR includes changes that updates setting up the docker container and how nebula, libiio, and telemetry are updated if needed.

1. The default docker image used is now set to test-harness-ci:latest. This image already has pre-installed nebula, libiio, and telemetry, all are based from master branch.
2. Reinstalling the libraries ( nebula, libiio, and telemetry ) upon setup is also possible by still using the set_env method to set the repo link and repo branch. A function to check if there is difference of the newly set and default is placed to see if there is a need to update the libraries: _check_update_container_lib_
3. If needed to update the libraries ( nebula, libiio, and telemetry ) upon setup base on master, it is possible to use the  _update_container_lib_ and set it to true. This will force to update the libraries base on master branch.
4. A small change was also implemented in updating the libraries on the agent itself, it is now default to not reinstall the requirements.txt but may set it to do so by setting _update_lib_requirements_ to true.