### PR TITLE
pyadi-iio: add checkout scm

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -1379,8 +1379,10 @@ def isMultiBranchPipeline() {
     println("Checking if multibranch pipeline..")
     try
     {
-        checkout scm
-        isMultiBranch = true
+        retry(3){
+            checkout scm
+            isMultiBranch = true
+        }
     }
     catch(all)
     {

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -490,7 +490,16 @@ def stage_library(String stage_name) {
                         dir('pytest-libiio'){
                             run_i('python3 setup.py install', true)
                         }
-                        run_i('git clone -b "' + gauntEnv.pyadi_iio_branch + '" ' + gauntEnv.pyadi_iio_repo, true)
+                        //scm pyadi-iio
+                        dir('pyadi-iio'){
+                            under_scm = isMultiBranchPipeline()
+                            if (under_scm){
+                                 println("Multibranch pipeline. Checkout scm")
+                            }else{
+                                println("Not a multibranch pipeline. Cloning "+gauntEnv.no_os_branch+" branch from "+gauntEnv.no_os_repo)
+                                run_i('git clone -b "' + gauntEnv.pyadi_iio_branch + '" ' + gauntEnv.pyadi_iio_repo+' .', true)
+                            }
+                        }
                         dir('pyadi-iio')
                         {
                             run_i('pip3 install -r requirements.txt', true)


### PR DESCRIPTION
In pyadi-iio test stage, I added a feature to enable checkout scm. It is still possible to pass pyadi-iio branch and repo if the pipeline is not multibranch.