### PR TITLE
Support MATLAB network license

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -978,7 +978,7 @@ private def run_agents() {
     def update_lib_requirements = gauntEnv.update_lib_requirements
     def jobs = [:]
     def num_boards = gauntEnv.boards.size()
-    def docker_args = getDockerConfig(gauntEnv.docker_args)
+    def docker_args = getDockerConfig(gauntEnv.docker_args, gauntEnv.matlab_license)
     def enable_update_boot_pre_docker = gauntEnv.enable_update_boot_pre_docker
     def enable_resource_queuing = gauntEnv.enable_resource_queuing
     def pre_docker_cls = stage_library("UpdateBOOTFiles")
@@ -1359,6 +1359,15 @@ def set_matlab_commands(List matlab_commands) {
  */
 def set_matlab_timeout(matlab_timeout) {
     gauntEnv.matlab_timeout = matlab_timeout
+}
+
+/**
+ * Set type of MATLAB license file
+ * @param matlab_license acceptable values are 'network' for 'machine'
+ * 'network' for network license and 'machine' for machine-specific license
+ */
+def set_matlab_license(matlab_license) {
+    gauntEnv.matlab_license = matlab_license
 }
 
 /**

--- a/vars/getDockerConfig.groovy
+++ b/vars/getDockerConfig.groovy
@@ -1,5 +1,5 @@
 
-def call(java.util.ArrayList listOfResources, matlabHSPro=true, UseNFS=false) {
+def call(java.util.ArrayList listOfResources, matlablic, matlabHSPro=true, UseNFS=false) {
     assert listOfResources instanceof java.util.List
 
     args = ['--privileged']
@@ -15,18 +15,20 @@ def call(java.util.ArrayList listOfResources, matlabHSPro=true, UseNFS=false) {
                 else
                     args.add('-v "/nfs/apps/resources/mlhsp":"/mlhspro":ro')
             }
-        else {
-                args.add('-v "/usr/local/MATLAB":"/usr/local/MATLAB":ro')
-                args.add('-v "/root/.matlab":"/root/.matlabro":ro')
-                if (matlabHSPro)
-                    args.add('-v "/mlhsp":"/mlhsp":ro')
-                else
-                    args.add('-v "/mlhsp":"/mlhspro":ro')
-        }
-        // Add correct MAC to licenses work in Docker
-        withCredentials([string(credentialsId: 'MAC_ADDR', variable: 'MAC_ADDR')]) {
-            args.add('--mac-address ' + MAC_ADDR)
-        }
+            else {
+                    args.add('-v "/usr/local/MATLAB":"/usr/local/MATLAB":ro')
+                    args.add('-v "/root/.matlab":"/root/.matlabro":ro')
+                    if (matlabHSPro)
+                        args.add('-v "/mlhsp":"/mlhsp":ro')
+                    else
+                        args.add('-v "/mlhsp":"/mlhspro":ro')
+            }
+            // Add correct MAC to licenses work in Docker
+            if (matlablic.equalsIgnoreCase( 'machine' )) {
+                withCredentials([string(credentialsId: 'MAC_ADDR', variable: 'MAC_ADDR')]) {
+                    args.add('--mac-address ' + MAC_ADDR)
+                }
+            }
         }
         else if (listOfResources[i].equalsIgnoreCase( 'Vivado' )) {
             echo '----Adding Vivado Resources----'

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -68,6 +68,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             matlab_branch: 'master',
             matlab_commands: [],
             matlab_timeout: '10m',
+            matlab_license: 'machine',
             no_os_repo: 'https://github.com/analogdevicesinc/no-OS.git',
             no_os_branch: 'master',
             vivado_ver: '2019.1',


### PR DESCRIPTION
The MATLAB Tests stage requires a container to have the same MAC address as the machine-specific license file. The MAC address is automatically set when MATLAB is added as a requirement in the pipeline.  This also requires the docker host mode to be set to false.

Using a network license removes the need to set the MAC address in the container and docker host mode can now be set to true. I added matlab_license variable that can be set to either 'network' or 'machine' to support this change. The default value is still 'machine'.

These changes will not require updating the JenkinsfileHW in the toolbox repos but I plan to update them to:
- set the license to 'network'
- set docker host mode to true
- set lock agent to false - This lock was implemented as a workaround to MATLAB stage failures when during the development of the stage. The real cause of the errors was never discovered. However, after testing these changes, the errors are not reproducible anymore.