### PR TITLE
fix config generation when no variant or no children

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -91,12 +91,15 @@ private def update_agent() {
                         }else if(gauntEnv.nebula_config_source == 'netbox'){
                             run_i('mkdir nebula-config')
                             dir('nebula-config'){
-                                def custom = null
+                                def custom = ""
                                 if(gauntEnv.netbox_include_variants == false){
-                                    custom = " --no-include-variants"
+                                    custom = custom + " --no-include-variants"
                                 }
                                 if(gauntEnv.netbox_include_children == false){
-                                    custom = " --no-include-children"
+                                    custom = custom + " --no-include-children"
+                                }
+                                if(custom==""){
+                                    custom = null
                                 }
                                 
                                 def command_str = 'gen-config-netbox'

--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -93,10 +93,10 @@ private def update_agent() {
                             dir('nebula-config'){
                                 def custom = null
                                 if(gauntEnv.netbox_include_variants == false){
-                                    custom = custom + " --no-include-variants"
+                                    custom = " --no-include-variants"
                                 }
                                 if(gauntEnv.netbox_include_children == false){
-                                    custom = custom + " --no-include-children"
+                                    custom = " --no-include-children"
                                 }
                                 
                                 def command_str = 'gen-config-netbox'


### PR DESCRIPTION
This is a fix to generating nebula config when adding variant or children is false.