### PR TITLE
Remove deprecated logJira method

### DIFF
--- a/Jenkinsfile-template
+++ b/Jenkinsfile-template
@@ -35,7 +35,6 @@ lock(label: 'adgt_test_harness_boards'){
     harness.set_docker_host_mode(true) //set to false for MATLAB jobs
     harness.set_send_telemetry(true)
     harness.set_enable_resource_queuing(true)
-    harness.set_log_jira(false)
 
     harness.set_elastic_server('192.168.10.1')
 

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -83,8 +83,6 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             kuiper_checker_branch: 'master',
             send_results: false,
             elastic_logs : [:],
-            log_jira: false,
-            log_jira_stages: [],
             max_retry: 3,
             recovery_ref: "SD",
             log_artifacts: false,


### PR DESCRIPTION
This should reduce Gauntlet bytecode size enough to make the adgt-test-harness branch usable.