### PR TITLE
Use nebula-config from pipeline workspace

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -43,7 +43,10 @@ private def setup_agents() {
             node(agent_name) {
                 stage('Query agents') {
                     // Get necessary configuration for basic work
-                    board = nebula('update-config board-config board-name')
+                    if (gauntEnv.workspace == '') {
+                        gauntEnv.workspace = env.WORKSPACE
+                    }
+                    board = nebula('update-config board-config board-name -y ' + gauntEnv.workspace + '/nebula-config/' + agent_name)
                     board_map[agent_name] = board
                 }
             }
@@ -121,12 +124,12 @@ private def update_agent() {
                             println(gauntEnv.nebula_config_source + ' as config source is not supported yet.')
                         }
                         
-                        if (fileExists('nebula-config/' + agent_name)){
-                            run_i('sudo mv nebula-config/' + agent_name + ' /etc/default/nebula')
-                        }else{
-                            // create and empty file
-                            run_i('sudo mv nebula-config/null-agent' + ' /etc/default/nebula')
-                        }
+                        // if (fileExists('nebula-config/' + agent_name)){
+                        //     run_i('sudo mv nebula-config/' + agent_name + ' /etc/default/nebula')
+                        // }else{
+                        //     // create and empty file
+                        //     run_i('sudo mv nebula-config/null-agent' + ' /etc/default/nebula')
+                        // }
                         
                     }
                 }
@@ -971,6 +974,7 @@ private def run_agents() {
     docker_args.add('-v /etc/default:/default:ro')
     docker_args.add('-v /dev:/dev')
     docker_args.add('-v /etc/timezone:/etc/timezone:ro')
+    
     docker_args.add('-v /etc/localtime:/etc/localtime:ro')
     if (gauntEnv.docker_host_mode) {
         docker_args.add('--network host')
@@ -1014,16 +1018,18 @@ private def run_agents() {
         def k
         def ml_variants = ['rx','tx','rx_tx']
         def ml_variant_index = 0
+        def docker_args_agent = ''
         node(agent) {
             try {
+                docker_args_agent = docker_args + ' -v '+ gauntEnv.workspace + '/nebula-config/' + env.NODE_NAME + ':/tmp/nebula:ro'
                 if (enable_update_boot_pre_docker_flag)
                     pre_docker_closure.call(board)
-                docker.image(docker_image_name).inside(docker_args) {
+                docker.image(docker_image_name).inside(docker_args_agent) {
                     try {
                         stage('Setup Docker') {
                             sh 'apt-get clean'
                             sh 'cd /var/lib/apt && mv lists lists.bak; mkdir -p lists/partial'
-                            sh 'cp /default/nebula /etc/default/nebula'
+                            sh 'cp /tmp/nebula /etc/default/nebula'
                             sh 'cp /default/pip.conf /etc/pip.conf || true'
                             sh 'cp /default/pydistutils.cfg /root/.pydistutils.cfg || true'
                             sh 'mkdir -p /root/.config/pip && cp /default/pip.conf /root/.config/pip/pip.conf || true'

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -94,6 +94,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             ml_test_stages: 0,
             internal_stages_to_skip: [:], // Number of stages to skip. Used for test skipping for MATLAB
             update_lib_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
-            update_container_lib: false // Set to true to force update libiio, nebula, telemetry base on master branch inside docker container
+            update_container_lib: false, // Set to true to force update libiio, nebula, telemetry base on master branch inside docker container
+            workspace: ''
     ]
 }

--- a/vars/getGauntEnv.groovy
+++ b/vars/getGauntEnv.groovy
@@ -95,6 +95,7 @@ private def call(hdlBranch, linuxBranch, bootPartitionBranch,firmwareVersion, bo
             internal_stages_to_skip: [:], // Number of stages to skip. Used for test skipping for MATLAB
             update_lib_requirements: false, // Set to true to run installation of requirements.txt of nebula and telemetry
             update_container_lib: false, // Set to true to force update libiio, nebula, telemetry base on master branch inside docker container
-            workspace: ''
+            workspace: '',
+            build_no: ''
     ]
 }


### PR DESCRIPTION
These changes enable mounting workspace specific nebula-config files in the docker containers instead of mounting the /etc/default/nebula file found in the agent.

These changes are made to support DUT locking such that several pipelines can run simultaneously - generating their own updated nebula-config.
