### PR TITLE
Run MATLAB as non-root user

### DIFF
--- a/src/sdg/Gauntlet.groovy
+++ b/src/sdg/Gauntlet.groovy
@@ -642,7 +642,8 @@ def stage_library(String stage_name) {
                 ])
                 createMFile()
                 try{
-                    cmd = 'IIO_URI="ip:'+ip+'" board="'+board+'" M2K_URI="'+getURIFromSerial(board)+'"'
+                    cmd = 'chown -R user $(pwd) ; ' 
+                    cmd += 'sudo -u user IIO_URI="ip:'+ip+'" board="'+board+'" M2K_URI="'+getURIFromSerial(board)+'"'
                     cmd += ' elasticserver='+gauntEnv.elastic_server+' timeout -s KILL '+gauntEnv.matlab_timeout
                     cmd += ' /usr/local/MATLAB/'+gauntEnv.matlab_release+'/bin/matlab -nosplash -nodesktop -nodisplay'
                     cmd += ' -r "run(\'matlab_commands.m\');exit"'


### PR DESCRIPTION
This should fix the license issues on the MATLAB pipelines by using a user other than root. The non-root "user" requires write permission to the workspace. The necessary docker image changes are already merged. I tested these changes using the [Transceiver Toolbox](http://gateway.englab/jenkins/job/MATLAB_Toolboxes/job/Transceiver_Toolbox_Hardware_Tests/job/master/133/) which uses nucs 1 and 2, as well as the [Precision Toolbox ](http://gateway.englab/jenkins/job/MATLAB_Toolboxes/job/Precision_Toolbox/job/main/54/)which uses nuc4.